### PR TITLE
Fixes compilation issue

### DIFF
--- a/host/meson.build
+++ b/host/meson.build
@@ -20,6 +20,7 @@ lib_sui_host = static_library(
 	dependencies: [
 		sui_protos,
 		sui_gfx,
+		koio,
 
 		egl,
 		glesv2,

--- a/meson.build
+++ b/meson.build
@@ -71,7 +71,7 @@ sui_libs = [
 lib_chopsui = library(
 	'chopsui',
 	link_whole: sui_libs,
-	dependencies: [wayland_client],
+	dependencies: [wayland_client, koio],
 	include_directories: sui_inc,
 	install: true,
 )


### PR DESCRIPTION
I had to make the following changes to compile it when I installed koio into `$HOME/.local`. i.e. 

```
PKG_CONFIG_PATH=$HOME/.local/lib/x86_64-linux-gnu/pkgconfig meson --prefix $HOME/.local build install
```